### PR TITLE
Added Makefile and build.lisp script.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,20 +2,38 @@
 # refering this image, when VBoxManage is present in the PATH.
 # An example of alternative image creation target is given: $(OTHER).image.
 
-all:mezzano.vmdk
+all:help
+
+HELP_FMT="%s %-30s \# %s\\n"
+M=$(notdir $(MAKE))
+vars:
+	@echo M=$(M)
+	@echo HELP_FMT=$(HELP_FMT)
+help:
+	@printf $(HELP_FMT) $(M) image "makes the mezzano image."
+	@printf $(HELP_FMT) $(M) vmdk "makes the mezzano.vmdk file for Virtual Box."
+	@printf $(HELP_FMT) $(M) launch-file-server "launches the file server in a screen."
+
 image:mezzano.image
+vmdk: mezzano.vmdk
 
 %.vmdk:%.image
 	-rm -f $@
-	type -p VBoxManage 2>/dev/null  && VBoxManage internalcommands createrawvmdk -filename $@ -rawdisk $(abspath $<)
+	type -p VBoxManage >/dev/null  && VBoxManage internalcommands createrawvmdk -filename $@ -rawdisk $(abspath $<)
 
-mezzano.image:Makefile $(shell find . -name \*.lisp -print\)
+mezzano.image:$(shell find . -name \*.lisp -print\)
 	sbcl --no-userinit --load build.lisp --eval '(sb-ext:quit)'
 
 other:other-mezzano.vmdk
 OTHER=other-mezzano
 $(OTHER).image:Makefile $(shell find . -name \*.lisp -print\)
 	sbcl --no-userinit --eval '(defvar *image-name* "'$(OTHER)'")' --load build.lisp --eval '(sb-ext:quit)'
-# Alternative quicklisp directory: --eval '(defvar *quicklisp-directory* #P"/alternative/quicklisp/")'
+# Alternative quicklisp directory: --eval '(defvar *quicklisp-directory* #P/alternative/quicklisp/)'
 
-.PHONY:image other
+
+launch-file-server:
+	screen -d -m -t mezzanofileserver  -c mezzano.screenrc \
+         bash -c 'export LC_CTYPE=en_US.UTF-8 ; while sleep 2 ; do sbcl --no-userinit --load file-server.lisp  ; done'
+
+.PHONY: help image vmdk other start-file-server
+.SUFFIXES: image vmdk

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ vmdk: mezzano.vmdk
 
 %.vmdk:%.image
 	-rm -f $@
-	type -p VBoxManage >/dev/null  && VBoxManage internalcommands createrawvmdk -filename $@ -rawdisk $(abspath $<)
+	( type -p VBoxManage >/dev/null && VBoxManage internalcommands createrawvmdk -filename $@ -rawdisk $(abspath $<) ) \
+	|| ( type -p qemu-img && qemu-img convert -f raw -O vmdk $(abspath $<) $@ )
 
 mezzano.image:$(shell find . -name \*.lisp -print\)
 	sbcl --no-userinit --load build.lisp --eval '(sb-ext:quit)'

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ vmdk: mezzano.vmdk
 	( type -p VBoxManage >/dev/null && VBoxManage internalcommands createrawvmdk -filename $@ -rawdisk $(abspath $<) ) \
 	|| ( type -p qemu-img && qemu-img convert -f raw -O vmdk $(abspath $<) $@ )
 
+# alternative: VBoxManage convertfromraw --format vmdk mezzano.image mezzano.vmdk
+
 mezzano.image:$(shell find . -name \*.lisp -print\)
 	sbcl --no-userinit --load build.lisp --eval '(sb-ext:quit)'
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# This GNU makefile builds the mezzano image, and creates a Virtual Box vmdk
+# refering this image, when VBoxManage is present in the PATH.
+# An example of alternative image creation target is given: $(OTHER).image.
+
+all:mezzano.vmdk
+image:mezzano.image
+
+%.vmdk:%.image
+	-rm -f $@
+	type -p VBoxManage 2>/dev/null  && VBoxManage internalcommands createrawvmdk -filename $@ -rawdisk $(abspath $<)
+
+mezzano.image:Makefile $(shell find . -name \*.lisp -print\)
+	sbcl --no-userinit --load build.lisp --eval '(sb-ext:quit)'
+
+other:other-mezzano.vmdk
+OTHER=other-mezzano
+$(OTHER).image:Makefile $(shell find . -name \*.lisp -print\)
+	sbcl --no-userinit --eval '(defvar *image-name* "'$(OTHER)'")' --load build.lisp --eval '(sb-ext:quit)'
+# Alternative quicklisp directory: --eval '(defvar *quicklisp-directory* #P"/alternative/quicklisp/")'
+
+.PHONY:image other

--- a/README.pjb
+++ b/README.pjb
@@ -53,6 +53,7 @@ Procedure
           RAM: 1GB 
           HD: the mezzano.vmdk
           Ethernet: select the virtio-net adapter
+          Serial port: assign the serial port COM1 to some raw file where the logs will be written.
    and boot it.
 
 

--- a/README.pjb
+++ b/README.pjb
@@ -1,0 +1,16 @@
+
+0- edit configure.lisp and ipl-configure.lisp to match your environment.
+
+1- launch the file server in a detached screen:
+
+    make launch-file-server
+
+2- compile the mezzano.image:
+
+    make image
+
+3- generate a vmdk for Virtual Box referencing mezzano.image
+
+    make vmdk
+
+4- launch Virtual Box, create a new VM with 1GB RAM and the mezzano.vmdk, and boot it.

--- a/README.pjb
+++ b/README.pjb
@@ -23,6 +23,10 @@ Procedure
    ipl-configure.lisp.  Later we may add some auto-configuration of
    the file server default IP, and the source directory path).
 
+
+   /!\ For now, we must also edit the pathnames in ipl.lisp.
+
+
 1- install the dependencies (once):
 
    make install-dependencies
@@ -45,7 +49,11 @@ Procedure
 
     make vmdk
 
-6- launch Virtual Box, create a new VM with 1GB RAM and the mezzano.vmdk, and boot it.
+6- launch Virtual Box, create a new VM:
+          RAM: 1GB 
+          HD: the mezzano.vmdk
+          Ethernet: select the virtio-net adapter
+   and boot it.
 
 
 Initially loading the whole system takes approximately 2 hours in

--- a/README.pjb
+++ b/README.pjb
@@ -2,7 +2,7 @@ I added a Makefile, lisp scripts and modified ipl.lisp to simplify and
 automatize the configuration, installation and building of Mezzano.
 
 Requirements
-------------
+============
 
 Unix tools:
 
@@ -14,7 +14,7 @@ Unix tools:
     
 
 Procedure
----------
+=========
     
 0- edit configure.lisp and ipl-configure.lisp to match your environment.
 
@@ -61,8 +61,20 @@ VirtualBox running on a 2.4GHz Core 2 Quad.
 
 
 Debugging
----------
+=========
 
 To test the connection with the file server:
 
    (sys.net::ping-host "192.168.x.y")
+
+
+
+Troobleshooting
+===============
+
+Hang on New ARP Table (and eventually time out)
+-----------------------------------------------
+
+This seems to occur when we reboot the VM.  We have to use power
+down/relaunch, for a cold start, not reboot.
+

--- a/build.lisp
+++ b/build.lisp
@@ -1,0 +1,37 @@
+;; Build Instructions
+;; ------------------
+
+;; Tested under SBCL 1.2.4
+(setf sb-impl::*default-external-format* :utf-8)
+
+(defvar *image-name*          "mezzano")
+(defvar *this-directory*      (make-pathname :name nil :type nil :version nil
+                                             :defaults #.(or *compile-file-pathname* *load-pathname*)))
+(defvar *quicklisp-directory* (merge-pathnames #P"quicklisp/" (user-homedir-pathname) nil))
+
+(load (merge-pathnames #P"setup.lisp" *quicklisp-directory* nil))
+(push (merge-pathnames #P"./file-server/" *this-directory* nil) asdf:*central-registry*)
+(push (merge-pathnames #P"./"             *this-directory* nil) asdf:*central-registry*)
+
+;; Load the remote filesystem server.
+(ql:quickload :lispos-file)
+(file-server::spawn-file-server)
+
+;; Load the cross build environment.
+(ql:quickload :lispos)
+
+;; Initialize the empty cross environment.
+(with-compilation-unit ()
+  (sys.c::set-up-cross-compiler)
+  (mapc 'sys.c::load-for-cross-compiler cold-generator::*supervisor-source-files*)
+  (mapc 'sys.c::load-for-cross-compiler cold-generator::*source-files*)
+  (mapc 'sys.c::load-for-cross-compiler cold-generator::*warm-source-files*))
+
+;; Modifiy ipl.lisp to taste.
+
+;; Build a cold image.
+(cold-generator::make-image *image-name* :header-path "tools/disk_header")
+
+;; This will produce a raw disk image called mezzano.image in the current directory.
+
+

--- a/configuration.lisp
+++ b/configuration.lisp
@@ -1,0 +1,15 @@
+#+sbcl (setf sb-impl::*default-external-format* :utf-8)
+
+(defvar *image-name*          "mezzano")
+(defvar *this-directory*
+  (make-pathname :name nil :type nil :version nil
+                 :defaults #.(or *compile-file-pathname* *load-pathname*)))
+(defvar *quicklisp-directory*
+  (merge-pathnames #P"quicklisp/" (user-homedir-pathname) nil))
+
+
+(load (merge-pathnames #P"setup.lisp" *quicklisp-directory* nil))
+(push (merge-pathnames #P"./file-server/" *this-directory* nil) asdf:*central-registry*)
+(push (merge-pathnames #P"./"             *this-directory* nil) asdf:*central-registry*)
+
+;;;; THE END ;;;;

--- a/file-server.lisp
+++ b/file-server.lisp
@@ -1,12 +1,12 @@
 ;;;; -*- mode:lisp;coding:utf-8 -*-
 ;;;;**************************************************************************
-;;;;FILE:               build.lisp
+;;;;FILE:               file-server.lisp
 ;;;;LANGUAGE:           Common-Lisp
 ;;;;SYSTEM:             Common-Lisp
 ;;;;USER-INTERFACE:     NONE
 ;;;;DESCRIPTION
 ;;;;    
-;;;;    This scripts compiles and generate the mezzano image.
+;;;;    This scripts starts the file server.
 ;;;;    
 ;;;;AUTHORS
 ;;;;    <PJB> Pascal J. Bourguignon <pjb@informatimago.com>
@@ -44,16 +44,8 @@
 (in-package :cl-user)
 (load "configuration.lisp")
 
-;; Load the cross build environment.
-(ql:quickload :lispos)
+;; Load the remote filesystem server.
+(ql:quickload :lispos-file)
+(file-server::spawn-file-server)
 
-;; Initialize the empty cross environment.
-(with-compilation-unit ()
-  (sys.c::set-up-cross-compiler)
-  (mapc 'sys.c::load-for-cross-compiler cold-generator::*supervisor-source-files*)
-  (mapc 'sys.c::load-for-cross-compiler cold-generator::*source-files*)
-  (mapc 'sys.c::load-for-cross-compiler cold-generator::*warm-source-files*))
-
-;; Build a cold image.
-(cold-generator::make-image *image-name* :header-path "tools/disk_header")
-;; This will produce a raw disk image called mezzano.image in the current directory.
+;;;; THE END ;;;;

--- a/install-dependencies.lisp
+++ b/install-dependencies.lisp
@@ -67,6 +67,9 @@
                   "git@github.com:Ramarren/png-read.git"))
     (format t "cloning ~A~%" repo) (finish-output)
     (uiop:run-program (list "git" "clone" repo)))
+  (dolist (resource '("http://upload.wikimedia.org/wikipedia/commons/7/73/Mandarin_Pair.jpg"))
+    (format t "getting ~A~%" resource) (finish-output)
+    (uiop:run-program (list "wget" resource)))
   (dolist (tarball '("http://common-lisp.net/project/iterate/releases/iterate-1.4.3.tar.gz"
                      "http://projects.tuxee.net/cl-vectors/files/cl-vectors-0.1.5.tar.gz"))
     (format t "getting ~A~%" tarball) (finish-output)

--- a/install-dependencies.lisp
+++ b/install-dependencies.lisp
@@ -82,7 +82,7 @@
   (ensure-directories-exist path)
   (with-open-file (conf path :direction :output :if-does-not-exist :create :if-exists :supersede)
     (print `(:source-registry
-             (:tree (namestring *file-server-home-directory*))
+             (:tree ,(namestring *file-server-home-directory*))
              :inherit-configuration)
            conf)
     (terpri)))

--- a/ipl-configuration.lisp
+++ b/ipl-configuration.lisp
@@ -3,15 +3,24 @@
   "The IP of the host where the file server is running.")
 
 (defparameter *file-server-source-directory*
-  (namestring (merge-pathnames "src/Mezzano/" (user-homedir-pathname)))
+  #.(namestring (merge-pathnames "src/Mezzano/" (user-homedir-pathname)))
   "A string containing the full path to the source tree on the host where the file server is running.")
 
 (defparameter *file-server-home-directory*
-  (namestring (merge-pathnames "Documents/Mezzano/" (user-homedir-pathname)))
+  #.(namestring (merge-pathnames "Documents/Mezzano/" (user-homedir-pathname)))
   "A string containing the the home directory containing the libraries.")
+
+(defparameter *desktop-image*
+  "Mandarin_Pair.jpg"
+  "The file-namestring of a picture used as desktop background.
+The default, Mandarin_Pair.jpg is automatically installed by install-dependencies.")
+
 
 ;; The *file-server-…-directory* variables contains path in the file
 ;; server host. the HOST component of those paths will be replaced by
 ;; "REMOTE" in the IPL to access the file server remotely.  This
 ;; allows this configuration to be used by install-dependencies.lisp
 
+;; Note: we cannot use pathname functions at run-time because the
+;; pathname subsystem is not initialized yet.  So we must use #. to
+;; compute the string in the host environment.

--- a/ipl-configuration.lisp
+++ b/ipl-configuration.lisp
@@ -1,6 +1,8 @@
-(defvar *file-server-ip* '(192 168 7 8))
-;; Use MAKE-PATHNAME instead of #p because the cross-compiler doesn't support #p.
-(defvar *file-server-root-directory*
-  (make-pathname :host :remote :directory '(:absolute "Users" "pjb" "Documents" "Mezzano")))
-(defvar *file-server-home-directory*
-  (merge-pathnames (make-pathname :directory '(:relative "Home")) *file-server-root-directory* nil))
+(progn
+ (defvar *file-server-ip* '(192 168 7 8))
+ ;; Use MAKE-PATHNAME instead of #p because the cross-compiler doesn't support #p.
+ (defvar *file-server-root-directory*
+   (make-pathname :host :remote :directory '(:absolute "Users" "pjb" "src" "Mezzano")))
+ (defvar *file-server-home-directory*
+   (make-pathname :host :remote :directory '(:absolute "Users" "pjb" "Documents" "Mezzano")))
+ )

--- a/ipl-configuration.lisp
+++ b/ipl-configuration.lisp
@@ -1,0 +1,6 @@
+(defvar *file-server-ip* '(192 168 7 8))
+;; Use MAKE-PATHNAME instead of #p because the cross-compiler doesn't support #p.
+(defvar *file-server-root-directory*
+  (make-pathname :host :remote :directory '(:absolute "Users" "pjb" "Documents" "Mezzano")))
+(defvar *file-server-home-directory*
+  (merge-pathnames (make-pathname :directory '(:relative "Home")) *file-server-root-directory* nil))

--- a/ipl.lisp
+++ b/ipl.lisp
@@ -95,8 +95,6 @@ If the compiled file is out of date, recompile it."
 ;; an undefined-function EXPORT error. This can be fixed by rebooting.
 (sys.int::cal (merge-pathnames "asdf/asdf.lisp" (user-homedir-pathname)))
 
-(format t "~&ASDF loaded.~%") (finish-output)
-
 ;; A bunch of GUI related systems.
 (require :zpb-ttf)
 (require :cl-vectors)
@@ -122,6 +120,7 @@ If the compiled file is out of date, recompile it."
 (sys.int::cal "gui/desktop.lisp")
 (sys.int::cal "gui/image-viewer.lisp")
 (sys.int::cal "applications/fs-viewer.lisp")
+
 ;; If the desktop image was removed above, then remove the :IMAGE argument
 ;; from here.
 (setf sys.int::*desktop* (eval (read-from-string "(mezzano.gui.desktop:spawn :image \"LOCAL:>Desktop.jpeg\")")))

--- a/ipl.lisp
+++ b/ipl.lisp
@@ -110,7 +110,6 @@ If the compiled file is out of date, recompile it."
 ;; And the GUI.
 (sys.int::cal "gui/font.lisp")
 (sys.int::cal "gui/widgets.lisp")
-(sys.int::cal "gui/desktop.lisp")
 (sys.int::cal "line-edit-mixin.lisp")
 (sys.int::cal "gui/popup-io-stream.lisp")
 (sys.int::cal "gui/xterm.lisp")

--- a/ipl.lisp
+++ b/ipl.lisp
@@ -2,30 +2,24 @@
 ;;;; This code is licensed under the MIT license.
 
 (in-package :cl-user)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  #.(with-open-file (in "ipl-configuration.lisp")
+      `(progn ,@(loop :for form = (read in nil in)
+                      :until (eq form in)
+                      :collect form))))
 
-;; #.(with-open-file (in "ipl-configuration.lisp")
-;;     `(progn ,@(loop :for form = (read in nil in)
-;;                     :until (eq form in)
-;;                     :collect form)))
-
-(defparameter *file-server-ip* '(192 168 7 8)
-  "The IP of the host where the file server is running.")
-
-(defparameter *file-server-source-directory*
-  (namestring (merge-pathnames "src/Mezzano/" (user-homedir-pathname)))
-  "A string containing the full path to the source tree on the host where the file server is running.")
-
-(defparameter *file-server-home-directory*
-  (namestring (merge-pathnames "Documents/Mezzano/" (user-homedir-pathname)))
-  "A string containing the the home directory containing the libraries.")
 
 ;; Fast eval mode.
 (setf sys.int::*eval-hook* 'mezzano.fast-eval:eval-in-lexenv)
 
 ;; Host where the initial system is kept.
 (mezzano.file-system.remote:add-simple-file-host :remote *file-server-ip*)
-(setf *default-pathname-defaults*            (parse-namestring *file-server-source-directory* :remote))
-(setf mezzano.file-system::*home-directory*  (parse-namestring *file-server-home-directory* :remote))
+;; (setf *default-pathname-defaults*            #.(parse-namestring *file-server-source-directory* "REMOTE"))
+;; (setf mezzano.file-system::*home-directory*  #.(parse-namestring *file-server-home-directory*   "REMOTE"))
+(setf *default-pathname-defaults*            (make-pathname :host "REMOTE"
+                                                            :directory '(:absolute "Users" "pjb" "src" "Mezzano")))
+(setf mezzano.file-system::*home-directory*  (make-pathname :host "REMOTE"
+                                                            :directory '(:absolute "Users" "pjb" "Documents" "Mezzano")))
 
 (defun sys.int::snapshot-and-exit ()
   (mezzano.supervisor:make-thread (lambda ()
@@ -88,7 +82,7 @@ If the compiled file is out of date, recompile it."
 ;; Other stuff.
 ;; The desktop image, this can be removed or replaced.
 ;; If it is removed, then the line below that starts the desktop must be updated.
-(sys.int::copy-file (merge-pathnames "Mandarin_Pair.jpg" (user-homedir-pathname))
+(sys.int::copy-file (merge-pathnames *desktop-image* (user-homedir-pathname))
                     "LOCAL:>Desktop.jpeg"
                     '(unsigned-byte 8))
 

--- a/ipl.lisp
+++ b/ipl.lisp
@@ -2,17 +2,15 @@
 ;;;; This code is licensed under the MIT license.
 
 (in-package :cl-user)
+(load "ipl-configuration.lisp")
 
 ;; Fast eval mode.
 (setf sys.int::*eval-hook* 'mezzano.fast-eval:eval-in-lexenv)
 
 ;; Host where the initial system is kept.
-(mezzano.file-system.remote:add-simple-file-host :remote '(192 168 0 4))
-;; Use MAKE-PATHNAME instead of #p because the cross-compiler doesn't support #p.
-(setf *default-pathname-defaults* (make-pathname :host :remote
-                                                 :directory '(:absolute "Users" "henry" "Documents" "Mezzanine")))
-(setf mezzano.file-system::*home-directory* (make-pathname :host :remote
-                                                           :directory '(:absolute "Users" "henry" "Documents" "Mezzanine-Home")))
+(mezzano.file-system.remote:add-simple-file-host :remote *file-server-ip*)
+(setf *default-pathname-defaults*            *file-server-root-directory*)
+(setf mezzano.file-system::*home-directory*  *file-server-home-directory*)
 
 (defun sys.int::snapshot-and-exit ()
   (mezzano.supervisor:make-thread (lambda ()

--- a/ipl.lisp
+++ b/ipl.lisp
@@ -95,6 +95,8 @@ If the compiled file is out of date, recompile it."
 ;; an undefined-function EXPORT error. This can be fixed by rebooting.
 (sys.int::cal (merge-pathnames "asdf/asdf.lisp" (user-homedir-pathname)))
 
+(format t "~&ASDF loaded.~%") (finish-output)
+
 ;; A bunch of GUI related systems.
 (require :zpb-ttf)
 (require :cl-vectors)

--- a/ipl.lisp
+++ b/ipl.lisp
@@ -105,6 +105,7 @@ If the compiled file is out of date, recompile it."
 ;; And the GUI.
 (sys.int::cal "gui/font.lisp")
 (sys.int::cal "gui/widgets.lisp")
+(sys.int::cal "gui/desktop.lisp")
 (sys.int::cal "line-edit-mixin.lisp")
 (sys.int::cal "gui/popup-io-stream.lisp")
 (sys.int::cal "gui/xterm.lisp")

--- a/ipl.lisp
+++ b/ipl.lisp
@@ -2,7 +2,7 @@
 ;;;; This code is licensed under the MIT license.
 
 (in-package :cl-user)
-(load "ipl-configuration.lisp")
+#.(with-open-file (in "ipl-configuration.lisp") (read in))
 
 ;; Fast eval mode.
 (setf sys.int::*eval-hook* 'mezzano.fast-eval:eval-in-lexenv)

--- a/mezzano.screenrc
+++ b/mezzano.screenrc
@@ -1,0 +1,65 @@
+#
+# Example of a user's .screenrc file
+#
+
+vbell on
+autodetach on
+startup_message off
+pow_detach_msg "Screen session of \$LOGNAME \$:cr:\$:nl:ende d."
+shell -$SHELL
+defscrollback 10000
+
+# xterm stuff:
+termcap  xterm hs@:cs=\E[%i%d;%dr:im=\E[4h:ei=\E[4l
+terminfo xterm hs@:cs=\E[%i%p1%d;%p2%dr:im=\E[4h:ei=\E[4l
+termcapinfo  xterm Z0=\E[?3h:Z1=\E[?3l:is=\E[r\E[m\E[2J\E[H\E[?7h\E[?1;4;6l
+termcapinfo xterm* OL=10000
+termcapinfo xterm 'VR=\E[?5h:VN=\E[?5l'
+termcapinfo xterm 'k1=\E[11~:k2=\E[12~:k3=\E[13~:k4=\E[14~'
+termcapinfo xterm 'kh=\E[1~:kI=\E[2~:kD=\E[3~:kH=\E[4~:kP=\E[H:kN=\E[6~'
+termcapinfo xterm 'hs:ts=\E]2;:fs=\007:ds=\E]2;screen\007'
+termcapinfo xterm 'vi=\E[?25l:ve=\E[34h\E[?25h:vs=\E[34l'
+termcapinfo   xterm 'XC=K%,%\E(B,[\304,\\\\\326,]\334,{\344,|\366,}\374,~\337'
+termcapinfo xterm ut
+
+# wyse terminals
+termcapinfo wy75-42 xo:hs@
+
+# New termcap sequences for cursor application mode.
+termcapinfo wy* CS=\E[?1h:CE=\E[?1l:vi=\E[?25l:ve=\E[?25h:VR=\E[?5h:VN=\E[?5l:cb=\E[1K:CD=\E[1J
+
+# Extend the vt100 desciption by some sequences.
+termcap  vt100* ms:AL=\E[%dL:DL=\E[%dM:UP=\E[%dA:DO=\E[%dB:LE=\E[%dD:RI=\E[%dC
+terminfo vt100* ms:AL=\E[%p1%dL:DL=\E[%p1%dM:UP=\E[%p1%dA:DO=\E[%p1%dB:LE=\E[%p1%dD:RI=\E[%p1%dC
+
+
+# keybindings
+
+#remove some stupid / dangerous key bindings
+bind k
+bind ^k
+bind .
+bind ^\
+bind \\
+bind ^h
+bind h
+#make them better
+bind 'K' kill
+bind 'I' login on
+bind 'O' login off
+bind '}' history
+
+# Yet another hack:
+# Prepend/append register [/] to the paste if ^a^] is pressed.
+# This lets me have autoindent mode in vi.
+register [ "\033:se noai\015a"
+register ] "\033:se ai\015a"
+bind ^] paste [.]
+
+
+
+
+hardstatus on 
+hardstatus alwayslastline 
+hardstatus string "%{.gW}%-w%{.rW}%n %t%{-}%+w %=%{..b}%H%{..r}%l%{..b}%m-%d %c"
+escape ^z^z

--- a/runtime/allocate.lisp
+++ b/runtime/allocate.lisp
@@ -16,8 +16,8 @@
 
 (defvar *wired-allocator-lock*)
 (defvar *allocator-lock*)
-(defvar *general-area-expansion-granularity* (* 128 1024 1024))
-(defvar *cons-area-expansion-granularity*    (* 128 1024 1024))
+(defvar *general-area-expansion-granularity* (* 16 1024 1024))
+(defvar *cons-area-expansion-granularity*    (* 16 1024 1024))
 
 (defun freelist-entry-next (entry)
   (sys.int::memref-t entry 1))

--- a/runtime/allocate.lisp
+++ b/runtime/allocate.lisp
@@ -16,8 +16,8 @@
 
 (defvar *wired-allocator-lock*)
 (defvar *allocator-lock*)
-(defvar *general-area-expansion-granularity* (* 4 1024 1024))
-(defvar *cons-area-expansion-granularity* (* 4 1024 1024))
+(defvar *general-area-expansion-granularity* (* 128 1024 1024))
+(defvar *cons-area-expansion-granularity*    (* 128 1024 1024))
 
 (defun freelist-entry-next (entry)
   (sys.int::memref-t entry 1))


### PR DESCRIPTION
This GNU makefile and build.lisp script build the mezzano image, and creates a Virtual Box vmdk
refering this image, when VBoxManage is present in the PATH.
An example of alternative image creation target is given: $(OTHER).image.
