### PR TITLE
Optimize the usage of *predicate-instructions*.

### DIFF
--- a/compiler/builtins.lisp
+++ b/compiler/builtins.lisp
@@ -1241,7 +1241,8 @@
              `(sys.lap-x86:cmp64 :r8 :r9)
              `(sys.lap-x86:mov64 :r8 nil)
              `(sys.lap-x86:mov64 :r9 t)
-             `(,',(fourth (predicate-info conditional)) :r8 :r9)
+             `(,',(predicate-instruction-cmov-instruction
+                   (predicate-info conditional)) :r8 :r9)
              resume)
        (setf *r8-value* (list (gensym))))))
 


### PR DESCRIPTION
Optimize the usage of *predicate-instructions* by converting it to a hash table.  Also create *predicate-instructions-by-jump*, which is used in tension-branches-1, after finding a major hotspot in using (find ... *predicate-instructions* :key #'third).