### PR TITLE
Have the editor make a backup files if variable is set

### DIFF
--- a/applications/editor.lisp
+++ b/applications/editor.lisp
@@ -1360,6 +1360,7 @@ Returns true when the screen is up-to-date, false if the screen is dirty and the
 (defun find-file-command ()
   (find-file (read-from-minibuffer (format nil "Find file (default ~S): " *default-pathname-defaults*))))
 
+(defvar *save-backup-files* t)
 (defun save-buffer-command ()
   (let ((buffer (current-buffer *editor*)))
     (when (not (buffer-property buffer 'path))

--- a/applications/editor.lisp
+++ b/applications/editor.lisp
@@ -1516,20 +1516,22 @@ If no such form is found, then return the CL-USER package."
     (unwind-protect
          (or (ignore-errors
                (save-excursion (buffer)
-                  (let ((point (copy-mark (buffer-point buffer))))
-                    (move-beginning-of-buffer buffer)
-                    (let* ((str (buffer-string buffer (buffer-point buffer) point))
-                           (pos (search (format nil "~A~A" #\( "in-package ") str :from-end t)))
-                      (when (and pos (or (= 0 pos)
-                                         (char= (char str (1- pos)) #\Newline)))
-                        (let ((form (let ((*package* temporary-package)
-                                          (*read-eval* nil))
-                                      (ignore-errors
-                                        (read-from-string (subseq str pos))))))
-                          (when (and (listp form)
-                                     (eql (first form) 'in-package)
-                                     (= (list-length form) 2))
-                            (return-from buffer-current-package (find-package (second form))))))))))
+                 (loop
+                    (beginning-of-top-level-form buffer)
+                    (mark-to-point buffer (buffer-mark buffer))
+                    (move-sexp buffer 1)
+                    (let* ((str (buffer-string buffer
+                                               (buffer-point buffer)
+                                               (buffer-mark buffer)))
+                           (form (let ((*package* temporary-package)
+                                       (*read-eval* nil))
+                                   (read-from-string str))))
+                      (when (and (listp form)
+                                 (eql (first form) 'in-package)
+                                 (= (list-length form) 2))
+                        (return (find-package (second form)))))
+                    (move-sexp buffer -1)
+                    (move-char buffer -1))))
              (find-package :cl-user))
       (delete-package temporary-package))))
 

--- a/applications/editor.lisp
+++ b/applications/editor.lisp
@@ -1367,6 +1367,13 @@ Returns true when the screen is up-to-date, false if the screen is dirty and the
              (filespec (merge-pathnames path)))
         (rename-buffer buffer (file-namestring filespec))
         (setf (buffer-property buffer 'path) filespec)))
+    ;; Make a backup of the file before writing, if it already exists
+    (when (and *save-backup-files*
+               (probe-file (buffer-property buffer 'path)))
+      (rename-file (buffer-property buffer 'path)
+                   (pathname (concatenate 'string
+                                          (namestring (buffer-property buffer 'path))
+                                          "~"))))
     (with-open-file (s (buffer-property buffer 'path)
                        :direction :output
                        :if-exists :new-version
@@ -1509,22 +1516,20 @@ If no such form is found, then return the CL-USER package."
     (unwind-protect
          (or (ignore-errors
                (save-excursion (buffer)
-                 (loop
-                    (beginning-of-top-level-form buffer)
-                    (mark-to-point buffer (buffer-mark buffer))
-                    (move-sexp buffer 1)
-                    (let* ((str (buffer-string buffer
-                                               (buffer-point buffer)
-                                               (buffer-mark buffer)))
-                           (form (let ((*package* temporary-package)
-                                       (*read-eval* nil))
-                                   (read-from-string str))))
-                      (when (and (listp form)
-                                 (eql (first form) 'in-package)
-                                 (= (list-length form) 2))
-                        (return (find-package (second form)))))
-                    (move-sexp buffer -1)
-                    (move-char buffer -1))))
+                  (let ((point (copy-mark (buffer-point buffer))))
+                    (move-beginning-of-buffer buffer)
+                    (let* ((str (buffer-string buffer (buffer-point buffer) point))
+                           (pos (search (format nil "~A~A" #\( "in-package ") str :from-end t)))
+                      (when (and pos (or (= 0 pos)
+                                         (char= (char str (1- pos)) #\Newline)))
+                        (let ((form (let ((*package* temporary-package)
+                                          (*read-eval* nil))
+                                      (ignore-errors
+                                        (read-from-string (subseq str pos))))))
+                          (when (and (listp form)
+                                     (eql (first form) 'in-package)
+                                     (= (list-length form) 2))
+                            (return-from buffer-current-package (find-package (second form))))))))))
              (find-package :cl-user))
       (delete-package temporary-package))))
 


### PR DESCRIPTION
If the variable *save-backup-files* is true, rename the old file to a new file with a ~ appeneded before saving the buffer over the original file.