### PR TITLE
Fixups to allow compilation of cl-ppcre

### DIFF
--- a/system/closette.lisp
+++ b/system/closette.lisp
@@ -1030,11 +1030,18 @@
 ;;; defgeneric
 
 (defmacro defgeneric (function-name lambda-list &rest options)
-  `(progn (ensure-generic-function
-           ',function-name
-           :lambda-list ',lambda-list
-           ,@(canonicalize-defgeneric-options options))
-          ,@(defgeneric-methods function-name options)))
+  (let ((decleration (when (and (listp (car options))
+				(eq (caar options) 'declare))
+		       (let ((decleration (car options)))
+			 (setf options (cdr options))
+			 decleration))))
+    `(progn
+       ,(substitute 'declaim 'declare decleration)
+       (ensure-generic-function
+	',function-name
+	:lambda-list ',lambda-list
+	,@(canonicalize-defgeneric-options options))
+       ,@(defgeneric-methods function-name options))))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
 

--- a/system/early-cons.lisp
+++ b/system/early-cons.lisp
@@ -491,14 +491,14 @@
       list
       (cons item list)))
 
-(defun subst (old new tree)
-  (cond ((eql old tree)
+(defun subst (old new tree &key (test #'eql))
+  (cond ((funcall test old tree)
          new)
         ((atom tree) tree)
-        (t (let ((a (subst old new (car tree)))
-                 (d (subst old new (cdr tree))))
-             (if (and (eql a (car tree))
-                      (eql d (cdr tree)))
+        (t (let ((a (subst old new (car tree) :test test))
+                 (d (subst old new (cdr tree) :test test)))
+             (if (and (funcall test a (car tree))
+                      (funcall test d (cdr tree)))
                  tree
                  (cons a d))))))
 


### PR DESCRIPTION
- add :test parameter to subst
- allow for declare as first line of defgeneric, as is allowed by http://www.ai.mit.edu/projects/iiip/doc/CommonLISP/HyperSpec/Body/mac_defgeneric.html