### PR TITLE
Update pathname handling; export additional APIs for McClim port; and…

### DIFF
--- a/gui/compositor.lisp
+++ b/gui/compositor.lisp
@@ -13,6 +13,7 @@
 
 (defvar *compositor* nil "Compositor thread.")
 (defvar *compositor-heartbeat* nil "Compositor heartbeat thread. Drives redisplay.")
+(defvar *compositor-debug-enable* nil)
 
 (defvar *event-queue* (mezzano.supervisor:make-fifo 50)
   "Internal FIFO used to submit events to the compositor.")
@@ -542,8 +543,9 @@ A passive drag sends no drag events to the window.")
 
 (defmethod process-event ((event window-create-event))
   (let ((win (window event)))
-    (format t "Registered new ~Dx~D window ~S.~%"
-            (width win) (height win) win)
+    (when *compositor-debug-enable*
+      (format t "Registered new ~Dx~D window ~S.~%"
+              (width win) (height win) win))
     (setf (window-x win) 0
           (window-y win) 0)
     (case (layer win)
@@ -609,7 +611,8 @@ A passive drag sends no drag events to the window.")
 
 (defmethod process-event ((event window-close-event))
   (let ((win (window event)))
-    (format t "Closing window ~S. Goodbye!~%" win)
+    (when *compositor-debug-enable*
+      (format t "Closing window ~S. Goodbye!~%" win))
     (setf *window-list* (remove win *window-list*))
     (when (eql *drag-window* win)
       (setf *drag-window* nil))

--- a/gui/package.lisp
+++ b/gui/package.lisp
@@ -83,7 +83,9 @@
            #:unsubscribe-notification
            #:get-window-by-kind
            #:screen-geometry-update
-           #:force-redisplay))
+           #:force-redisplay
+           #:window-x
+           #:window-y))
 
 (defpackage :mezzano.gui.input-drivers
   (:use :cl))

--- a/gui/widgets.lisp
+++ b/gui/widgets.lisp
@@ -24,7 +24,8 @@
            #:reset
            #:cursor-visible
            #:in-frame-header-p
-           #:in-frame-border-p))
+           #:in-frame-border-p
+           #:set-cursor-function))
 
 (in-package :mezzano.gui.widgets)
 


### PR DESCRIPTION
…, reduce default amount of debug messages.

fs.lisp - updates to bring functions more in line with the common lisp spec:

Modify make-pathname to handle the special case of directory being :wild correctly - set directory to (:absolute :wild-inferiors).

Modify pathname-match-directory to handle (:absolute :wild-inferiors) correctly - match any directory list.

Modify enough-namestring to compare pathnames field by field, then within a field. Then return the remaining portion.

Modify merge-pathname to handle the special case of having :back fields in a :relative directory list.

compositor.lisp - add enable/disable flag for debug messages.

gui/packages.lisp - export two additional APIs to support McClim port.

gui/widgets.lisp - export one additional API to support McClim port.