### PR TITLE
file-server: Implement directory deletion

### DIFF
--- a/file-server/server.lisp
+++ b/file-server/server.lisp
@@ -131,7 +131,10 @@
   (format *client* "~D~%" (file-write-date path)))
 
 (defcommand :delete (path)
-  (delete-file path)
+  (if (or (pathname-name path) (pathname-type path))
+      (delete-file path)
+      #+sbcl (sb-posix:rmdir path)
+      #-sbcl (error "delete of directories not implemented"))
   (format *client* ":ok~%"))
 
 (defun handle-client (*client*)


### PR DESCRIPTION
It is intended that delete-file on directories be able to delete the
directory. For this to work on remote filesystems, a way to delete
directories that works in the file-server's host Lisp is needed. On
SBCL, sb-posix:rmdir is used for this.