### PR TITLE
fix current-boot-id undefined bug

### DIFF
--- a/drivers/virtio-net.lisp
+++ b/drivers/virtio-net.lisp
@@ -102,7 +102,7 @@ and then some alignment.")
     (sup:debug-print-line "virtio-net device " nic " removed. Old boot: "
                           (virtio-net-boot-id nic)
                           " Current boot: "
-                          (current-boot-id))
+                          (sup:current-boot-id))
     (throw 'nic-detached nil)))
 
 (defun virtio-net-receive-processing (nic)

--- a/supervisor/virtio.lisp
+++ b/supervisor/virtio.lisp
@@ -502,6 +502,6 @@
   "Call when a driver is done with a device."
   (setf (virtio-device-claimed dev) nil)
   (sup:with-pseudo-atomic ()
-    (when (eql (virtio-device-boot-id dev) (current-boot-id))
+    (when (eql (virtio-device-boot-id dev) (sup:current-boot-id))
       ;; TODO: Maybe reprobe the device?
       (setf (virtio-device-status dev) +virtio-status-failed+))))


### PR DESCRIPTION
seems "sup:" is missing in these 2 places? (Causing undefined function error and finally cause panic)

Found when trying to throw 'nic-detached onto the virtio-net-driver worker thread, works after recompile.