### PR TITLE
NET: Refactor

### DIFF
--- a/net/arp.lisp
+++ b/net/arp.lisp
@@ -33,7 +33,6 @@
                (eql ptype mezzano.network.ethernet:+ethertype-ipv4+) (eql plen 4))
       (let ((spa (ub32ref/be packet spa-start))
             (tpa (ub32ref/be packet tpa-start)))
-        (format t "Got ARP packet. ~X ~X ~X ~X~%" spa tpa address oper)
         ;; If the pair <protocol type, sender protocol address> is
         ;; already in my translation table, update the sender
         ;; hardware address field of the entry with the new
@@ -66,8 +65,7 @@
             (setf (ub32ref/be packet spa-start) address
                   (ub16ref/be packet 20) +arp-op-reply+)
             (mezzano.network.ethernet:transmit-packet interface (list (subseq packet 0 44))))))
-      (mezzano.network.ip::arp-table-updated))
-    (format t "New ARP table: ~S~%" *arp-table*)))
+      (mezzano.network.ip::arp-table-updated))))
 
 (defun send-arp (interface ptype address)
   "Send an ARP packet out onto the wire."

--- a/net/ip.lisp
+++ b/net/ip.lisp
@@ -359,6 +359,9 @@ an (UNSIGNED-BYTE 32) or an IPV4-ADDRESS."
           (ldb (byte 8 8) argument)
           (ldb (byte 8 0) argument)))
 
+(defun ipv4-address-to-string (ipv4-address)
+  (format-ipv4-address nil (ipv4-address-address ipv4-address)))
+
 (defmethod print-object ((object ipv4-address) stream)
   (if (or *print-readably*
           *print-escape*)

--- a/net/package.lisp
+++ b/net/package.lisp
@@ -79,6 +79,7 @@
            #:tcp4-accept-connection
            #:tcp4-decline-connection
            #:wait-for-connections
+           #:close-tcp-listener
            #:tcp-listener-local-port
            #:tcp-connection-local-port
            #:tcp-connection-local-ip

--- a/net/package.lisp
+++ b/net/package.lisp
@@ -45,6 +45,7 @@
                 #:octet)
   (:export #:make-ipv4-address
            #:format-ipv4-address
+           #:ipv4-address-to-string
            #:invalid-ipv4-address
            #:parse-ipv4-address
            #:ipv4-interface-address
@@ -78,7 +79,12 @@
            #:tcp4-accept-connection
            #:tcp4-decline-connection
            #:wait-for-connections
-           #:close-tcp-listener
+           #:tcp-listener-local-port
+           #:tcp-connection-local-port
+           #:tcp-connection-local-ip
+           #:tcp-connection-remote-port
+           #:tcp-connection-remote-ip
+           #:tcp-stream-connection
            #:network-error
            #:connection-error
            #:connection-error-host

--- a/net/tcp.lisp
+++ b/net/tcp.lisp
@@ -436,6 +436,8 @@
                                                   :capacity backlog)
                                     :local-port local-port
                                     :local-ip source-address)))
+      (when (get-tcp-listener source-address local-port)
+        (error "Server already listening on port ~D" local-port))
       (mezzano.supervisor:with-mutex (*tcp-listener-lock*)
         (push listener *tcp-listeners*))
       listener)))

--- a/net/tcp.lisp
+++ b/net/tcp.lisp
@@ -26,8 +26,6 @@
 (defvar *tcp-listeners* nil)
 (defvar *tcp-listener-lock* (mezzano.supervisor:make-mutex "TCP connection list"))
 
-(defvar *server-alist* '())
-
 (defclass tcp-listener ()
   ((local-port :accessor tcp-listener-local-port :initarg :local-port)
    (local-ip :accessor tcp-listener-local-ip :initarg :local-ip)
@@ -136,9 +134,7 @@
                     (tcp-listener-connections listener)
                     :wait-p nil)
                (mezzano.supervisor:with-mutex (*tcp-connection-lock*)
-                 (push connection *tcp-connections*)))))
-          ((eql flags +tcp4-flag-syn+)
-           (tcp4-establish-connection local-ip local-port remote-ip remote-port packet start end)))))
+                 (push connection *tcp-connections*))))))))
 
 (defun tcp4-accept-connection (connection)
   (let* ((seq (random #x100000000))
@@ -151,26 +147,6 @@
 
 (defun tcp4-decline-connection (connection)
   (detach-tcp-connection connection))
-
-(defun tcp4-establish-connection (local-ip local-port remote-ip remote-port packet start end)
-  (let* ((seq (ub32ref/be packet (+ start +tcp4-header-sequence-number+)))
-         (blah (random #x100000000))
-         (connection (make-instance 'tcp-connection
-                                    :%state :syn-received
-                                    :local-port local-port
-                                    :local-ip local-ip
-                                    :remote-port remote-port
-                                    :remote-ip remote-ip
-                                    :s-next (logand #xFFFFFFFF (1+ blah))
-                                    :r-next (logand #xFFFFFFFF (1+ seq))
-                                    :window-size 8192)))
-    (let ((server (assoc local-port *server-alist*)))
-      (cond (server
-             (mezzano.supervisor:with-mutex (*tcp-connection-lock*)
-               (push connection *tcp-connections*))
-             (tcp4-send-packet connection blah (logand #xFFFFFFFF (1+ seq)) nil
-                               :ack-p t :syn-p t)
-             (funcall (second server) connection))))))
 
 (defun detach-tcp-connection (connection)
   (mezzano.supervisor:with-mutex (*tcp-connection-lock*)

--- a/net/tcp.lisp
+++ b/net/tcp.lisp
@@ -654,6 +654,10 @@
   (declare (ignore abort))
   (close-tcp-connection (tcp-stream-connection stream)))
 
+(defmethod close ((listener tcp-listener) &key abort)
+  (declare (ignore abort))
+  (close-tcp-listener listener))
+
 (defmethod open-stream-p ((stream tcp-octet-stream))
   (not (tcp-connection-closed-p stream)))
 

--- a/net/tcp.lisp
+++ b/net/tcp.lisp
@@ -693,10 +693,6 @@
   (declare (ignore abort))
   (close-tcp-connection (tcp-stream-connection stream)))
 
-(defmethod close ((listener tcp-listener) &key abort)
-  (declare (ignore abort))
-  (close-tcp-listener listener))
-
 (defmethod open-stream-p ((stream tcp-octet-stream))
   (not (tcp-connection-closed-p stream)))
 

--- a/net/tcp.lisp
+++ b/net/tcp.lisp
@@ -451,9 +451,9 @@
                                                   :capacity backlog)
                                     :local-port local-port
                                     :local-ip source-address)))
-      (when (get-tcp-listener source-address local-port)
-        (error "Server already listening on port ~D" local-port))
       (mezzano.supervisor:with-mutex (*tcp-listener-lock*)
+        (when (get-tcp-listener source-address local-port)
+          (error "Server already listening on port ~D" local-port))
         (push listener *tcp-listeners*))
       listener)))
 


### PR DESCRIPTION
TCP:
Remove old server code
Don't allow multiple servers lintening on same port
Add ipv4-address-to-string , close for tcp-listener and export functions

ARP:
Don't write defug info in arp.lisp