### PR TITLE
Add native GitHub "Sponsor" button linking to Patreon account

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: froggey


### PR DESCRIPTION
(I just found out that you're on Patreon, the link in the README is pretty easy to miss!)

----------------------------------

Simply merge this pull request and activate the "Sponsorships" option in Mezzano's project settings to get a cute little "Sponsor" button linking to your [Patreon account](https://www.patreon.com/froggey)!

Here's a [preview](https://github.com/Hexstream/Mezzano) of the end result.

Here's the [official documentation](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository) for this nice feature.

(Note that you do not need to be sponsored by GitHub to use this feature.)

----------------------------------

**Also [consider](https://twitter.com/HexstreamSoft/status/1193278064219885568) urgently applying to [GitHub Sponsors](https://github.com/sponsors) before 1 january 2020 to benefit from ✕2 matching!**