### PR TITLE
Fix build for MSYS2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.hex binary


### PR DESCRIPTION
Create .gitattributes to preserve line endings for unifont-5.1.20080820.hex, so build won't choke under MSYS2.