### PR TITLE
Fix system crash due to interrupt handler accessing specials not globals

### DIFF
--- a/doc/internals/supervisor-restrictions.md
+++ b/doc/internals/supervisor-restrictions.md
@@ -2,7 +2,7 @@ Writing code that runs as part of the supervisor comes with a few restrictions, 
 
 General restrictions:
 * No classes or methods. defclass/defmethod/defgeneric and the clos implementation in general are not written in a supervisor-safe way. Use structures and pass functions around instead.
-* Restrictions on allocation. Depending on what kind of supervisor code you are writing, you may need to consider what allocation area is used to allocate from. If the code accessing the allocated object may be called during GC or an interrupt handler the object must be allocated from the wired area.
+* Restrictions on allocation. Depending on what kind of supervisor code you are writing, you may need to consider what allocation area is used to allocate from. If the code accessing the allocated object may be called during GC or an interrupt handler the object must be allocated from the wired area.  For example, global variables accessed from interrupt handlers must be defined with defglobal, not defvar.  Defining them with defvar will result in rare crashes.
 * Restrictions on memory access. Depending on the context the code is called from (during a GC, for example), it may not be possible to access non-wired memory.
 
 The exact restrictions your code must follow, and the strength of them, are dependent on the context of the code.

--- a/supervisor/intel-8042.lisp
+++ b/supervisor/intel-8042.lisp
@@ -135,11 +135,13 @@ This assumes PS/2 scan code set 1 is in effect.")
 ;; Intel 8042 and PS/2 global variables.
 (defvar *intel-8042-present* nil
   "Whether or not a PS/2 controller is present.")
-(defvar *intel-8042-queue-keyboard* nil
+;; These must be sys.int::defglobal, not defvar'd normal special
+;; variables.  See doc/internals/supervisor-restrictions.md.
+(sys.int::defglobal *intel-8042-queue-keyboard* nil
   "The PS/2 controller keyboard port IRQ FIFO.")
-(defvar *intel-8042-queue-auxiliary* nil
+(sys.int::defglobal *intel-8042-queue-auxiliary* nil
   "The PS/2 controller auxiliary port IRQ FIFO.")
-(defvar *intel-8042-debug-dump-state* nil
+(sys.int::defglobal *intel-8042-debug-dump-state* nil
   "Whether or not to dump global state based on keyboard state.")
 
 (defun read-keyboard (&optional (wait-p t))


### PR DESCRIPTION
As discussed on IRC.

This fixes:

----- PANIC -----
Page fault with interrupts disabled on address 208003D0FCC0 Local CPU is #<792849>
Run queues:
Thread #<1A27F59 Thread Keyboard Forwarder> holds the world Run queue #<1412939>/SUPERVISOR:
Run queue #<1412959>/HIGH:
Run queue #<1412979>/NORMAL:
  #<17BECD9 Thread Desktop>/Desktop
Run queue #<1412999>/LOW:
IRQ state:
IRQ #<1A61B39 Irq :Number 0> - 0 (A4B delivered)
  #<1A37319> PIT [exclusive]
IRQ #<1A5EFB9 Irq :Number 1> - 1 (2 delivered)
  #<1A370D9> INTEL-8042-KEYBOARD [exclusive]
IRQ #<1A5DE89 Irq :Number 4> - 4 (0 delivered)
  #<1A745F9> #<1A747B9 Simple-Irq :Number 4 :State UNMASKED :Event-State NIL>
IRQ #<1A54D09 Irq :Number B> - B (15 delivered)
  #<15535F9> #<1A803F9 Simple-Irq :Number B :State UNMASKED :Event-State NIL>
IRQ #<1A54C79 Irq :Number C> - C (0 delivered)
  #<1A372B9> INTEL-8042-AUXILIARY [exclusive]
IRQ #<1A54B59 Irq :Number E> - E (116B delivered)
  #<1581629> #<1A77409> [exclusive]
IRQ #<1A54999 Irq :Number F> - F (0 delivered)
  #<157B929> #<1A6FBC9> [exclusive]
Active timers: (current time is F72E59D0)
  #<142D719>/SLEEP @ F7623C00
  #<15D4419>/#<1574369 Condition-Variable #<580000004CE9>> @ FA8D8A60
<truncated>
  #<15D7809>/SLEEP @ B0577D660
Thread #<1A27F59 Thread Keyboard Forwarder> ACTIVE #<1413C19 Event (IRQ-FIFO-DATA-AVAILABLE-EVENT #<1413B89>)> TIFH: 0 TPFH: NIL
20000121FB90 7FFF8923A5 DEBUG-DUMP
20000121FD20 7FFF800F2B (LAMBDA IN PANIC-1)
20000121FE30 7FFF80073F PANIC-1
20000121FE50 7FFF800633 PANIC
20000121FEC0 7FFF881C71 FATAL-PAGE-FAULT
20000121FEF0 7FFF880ADA %PAGE-FAULT-HANDLER
20000121FF40 7FFF87EF3B %%INTERRUPT-SERVICE-ROUTINES 20000121FFD0 7FFF80885F %SYMBOL-VALUE-CELL-BY-CELL 200000E1FD50 7FFF95854B HANDLE-INTERRUPT-REQUEST-KEYBOARD 200000E1FD90 7FFF8F33E6 IRQ-DELIVER
200000E1FE70 7FFF8F2259 I8259-INTERRUPT-HANDLER
200000E1FF00 7FFF88F51E %USER-INTERRUPT-HANDLER
200000E1FF40 7FFF87EF3B %%INTERRUPT-SERVICE-ROUTINES 200000E1FFD0 7FFF8286D3 %%RESTORE-PARTIAL-SAVE-THREAD <truncated>